### PR TITLE
"View all items" screen & edit item UI         

### DIFF
--- a/app/src/main/java/com/example/listit/MainActivity.kt
+++ b/app/src/main/java/com/example/listit/MainActivity.kt
@@ -7,6 +7,8 @@ import androidx.activity.compose.setContent
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import com.example.listit.presentation.navigation.SetupNavGraph
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import com.example.listit.ui.theme.ListItTheme
 
 @AndroidEntryPoint
@@ -19,10 +21,12 @@ class MainActivity : ComponentActivity() {
 
         setContent {
             ListItTheme {
-                navController = rememberNavController()
-                SetupNavGraph(
-                    navController = navController,
-                )
+                Surface(color = MaterialTheme.colorScheme.background) {
+                    navController = rememberNavController()
+                    SetupNavGraph(
+                        navController = navController,
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/listit/data/local/AppDatabase.kt
+++ b/app/src/main/java/com/example/listit/data/local/AppDatabase.kt
@@ -3,7 +3,7 @@ package com.example.listit.data.local
 import androidx.room.Database
 import androidx.room.RoomDatabase
 
-@Database(entities = [ListItemEntity::class, ItemListEntity::class], version = 3)
+@Database(entities = [ListItemEntity::class, ItemListEntity::class], version = 4)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun mainListDao(): MainListDao
     abstract fun itemListDao(): ItemListDao

--- a/app/src/main/java/com/example/listit/data/local/ItemListDao.kt
+++ b/app/src/main/java/com/example/listit/data/local/ItemListDao.kt
@@ -22,4 +22,7 @@ interface ItemListDao {
 
     @Query("UPDATE item_lists SET name = :name WHERE id = :id")
     suspend fun updateName(id: String, name: String)
+
+    @Query("SELECT colorIndex FROM item_lists")
+    suspend fun getAllColorIndices(): List<Int>
 }

--- a/app/src/main/java/com/example/listit/data/local/ItemListEntity.kt
+++ b/app/src/main/java/com/example/listit/data/local/ItemListEntity.kt
@@ -8,4 +8,5 @@ import androidx.room.PrimaryKey
 data class ItemListEntity(
     @PrimaryKey val id: String,
     @ColumnInfo val name: String,
+    @ColumnInfo val colorIndex: Int = 0,
 )

--- a/app/src/main/java/com/example/listit/data/mapper/ItemListMapper.kt
+++ b/app/src/main/java/com/example/listit/data/mapper/ItemListMapper.kt
@@ -3,6 +3,6 @@ package com.example.listit.data.mapper
 import com.example.listit.data.local.ItemListEntity
 import com.example.listit.domain.model.GroupOfItems
 
-fun ItemListEntity.toDomain(): GroupOfItems = GroupOfItems(id = id, name = name)
+fun ItemListEntity.toDomain(): GroupOfItems = GroupOfItems(id = id, name = name, colorIndex = colorIndex)
 
-fun GroupOfItems.toEntity(): ItemListEntity = ItemListEntity(id = id, name = name)
+fun GroupOfItems.toEntity(): ItemListEntity = ItemListEntity(id = id, name = name, colorIndex = colorIndex)

--- a/app/src/main/java/com/example/listit/data/repository/ListRepositoryImpl.kt
+++ b/app/src/main/java/com/example/listit/data/repository/ListRepositoryImpl.kt
@@ -25,4 +25,7 @@ class ListRepositoryImpl @Inject constructor(private val dao: ItemListDao) : Lis
 
     override suspend fun updateName(id: String, name: String) =
         dao.updateName(id, name)
+
+    override suspend fun getUsedColorIndices(): List<Int> =
+        dao.getAllColorIndices()
 }

--- a/app/src/main/java/com/example/listit/di/DatabaseModule.kt
+++ b/app/src/main/java/com/example/listit/di/DatabaseModule.kt
@@ -32,7 +32,7 @@ object DatabaseModule {
                 override fun onCreate(db: SupportSQLiteDatabase) {
                     super.onCreate(db)
                     db.execSQL(
-                        "INSERT OR IGNORE INTO item_lists (id, name) VALUES ('$DEFAULT_LIST_ID', '$DEFAULT_LIST_NAME')"
+                        "INSERT OR IGNORE INTO item_lists (id, name, colorIndex) VALUES ('$DEFAULT_LIST_ID', '$DEFAULT_LIST_NAME', 0)"
                     )
                 }
             })

--- a/app/src/main/java/com/example/listit/domain/model/GroupOfItems.kt
+++ b/app/src/main/java/com/example/listit/domain/model/GroupOfItems.kt
@@ -3,6 +3,7 @@ package com.example.listit.domain.model
 data class GroupOfItems(
     val id: String,
     val name: String,
+    val colorIndex: Int = 0,
 )
 
 const val DEFAULT_LIST_ID = "default"

--- a/app/src/main/java/com/example/listit/domain/repository/ListRepository.kt
+++ b/app/src/main/java/com/example/listit/domain/repository/ListRepository.kt
@@ -9,4 +9,5 @@ interface ListRepository {
     suspend fun insert(list: GroupOfItems)
     suspend fun deleteById(id: String)
     suspend fun updateName(id: String, name: String)
+    suspend fun getUsedColorIndices(): List<Int>
 }

--- a/app/src/main/java/com/example/listit/domain/usecase/AddListUseCase.kt
+++ b/app/src/main/java/com/example/listit/domain/usecase/AddListUseCase.kt
@@ -7,6 +7,14 @@ import javax.inject.Inject
 
 class AddListUseCase @Inject constructor(private val repository: ListRepository) {
     suspend operator fun invoke(name: String) {
-        repository.insert(GroupOfItems(id = UUID.randomUUID().toString(), name = name))
+        val usedIndices = repository.getUsedColorIndices().toSet()
+        val colorIndex = (0..7).firstOrNull { it !in usedIndices } ?: (usedIndices.size % 8)
+        repository.insert(
+            GroupOfItems(
+                id = UUID.randomUUID().toString(),
+                name = name,
+                colorIndex = colorIndex,
+            )
+        )
     }
 }

--- a/app/src/main/java/com/example/listit/presentation/components/AddItemBottomSheet.kt
+++ b/app/src/main/java/com/example/listit/presentation/components/AddItemBottomSheet.kt
@@ -1,0 +1,218 @@
+package com.example.listit.presentation.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.listit.presentation.home.GroupCardUiState
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AddItemBottomSheet(
+    groups: List<GroupCardUiState>,
+    initialGroupId: String,
+    onDismiss: () -> Unit,
+    onSave: (title: String, groupId: String) -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    var taskTitle by remember { mutableStateOf("") }
+    var selectedGroupId by remember { mutableStateOf(initialGroupId) }
+    val focusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.surfaceContainer,
+        shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp)
+                .padding(bottom = 32.dp),
+        ) {
+            // Title
+            Text(
+                text = "New Task",
+                style = MaterialTheme.typography.headlineSmall.copy(
+                    fontWeight = FontWeight.Bold,
+                ),
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            // Subtitle
+            Text(
+                text = "What's on your mind?",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // Text field
+            OutlinedTextField(
+                value = taskTitle,
+                onValueChange = { taskTitle = it },
+                placeholder = {
+                    Text(
+                        text = "I want to...",
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                    )
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .focusRequester(focusRequester),
+                shape = RoundedCornerShape(12.dp),
+                colors = OutlinedTextFieldDefaults.colors(
+                    focusedBorderColor = ListCardColor.BLUE.color,
+                    unfocusedBorderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f),
+                ),
+                singleLine = true,
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // Select list label
+            Text(
+                text = "SELECT LIST",
+                style = MaterialTheme.typography.labelMedium.copy(
+                    letterSpacing = 1.sp,
+                ),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // Horizontally scrollable group chips
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState()),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                groups.forEach { group ->
+                    val isSelected = group.groupId == selectedGroupId
+                    GroupChip(
+                        name = group.groupName,
+                        icon = group.style.icon,
+                        accentColor = group.style.accentColor.color,
+                        isSelected = isSelected,
+                        onClick = { selectedGroupId = group.groupId },
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(28.dp))
+
+            // Save button
+            Button(
+                onClick = {
+                    if (taskTitle.isNotBlank()) {
+                        onSave(taskTitle.trim(), selectedGroupId)
+                    }
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp),
+                shape = RoundedCornerShape(16.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = ListCardColor.BLUE.color,
+                ),
+                enabled = taskTitle.isNotBlank(),
+            ) {
+                Text(
+                    text = "Save Task",
+                    style = MaterialTheme.typography.bodyLarge.copy(
+                        fontWeight = FontWeight.SemiBold,
+                    ),
+                    color = Color.White,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun GroupChip(
+    name: String,
+    icon: ListCardIcon,
+    accentColor: Color,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+) {
+    val backgroundColor = if (isSelected) {
+        accentColor
+    } else {
+        MaterialTheme.colorScheme.surfaceContainerHighest
+    }
+    val contentColor = if (isSelected) {
+        Color.White
+    } else {
+        MaterialTheme.colorScheme.onSurfaceVariant
+    }
+
+    Row(
+        modifier = Modifier
+            .clip(RoundedCornerShape(12.dp))
+            .background(backgroundColor)
+            .clickable { onClick() }
+            .padding(horizontal = 16.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = icon.imageVector,
+            contentDescription = null,
+            tint = contentColor,
+            modifier = Modifier.size(18.dp),
+        )
+        Spacer(modifier = Modifier.width(6.dp))
+        Text(
+            text = name,
+            style = MaterialTheme.typography.bodyMedium.copy(
+                fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal,
+            ),
+            color = contentColor,
+        )
+    }
+}

--- a/app/src/main/java/com/example/listit/presentation/components/EditItemBottomSheet.kt
+++ b/app/src/main/java/com/example/listit/presentation/components/EditItemBottomSheet.kt
@@ -14,6 +14,8 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CheckboxDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
@@ -28,6 +30,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -37,21 +40,22 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.example.listit.domain.model.ListItem
 import com.example.listit.presentation.home.GroupCardUiState
 import com.example.listit.ui.theme.ListItTheme
 
 /**
- * A modal bottom sheet for creating a new task. Contains a text field for the task title,
- * horizontally scrollable group chips for selecting which list to add to, and a save button.
- * Pressing the keyboard Done action also triggers save.
+ * A modal bottom sheet for editing an existing task. Pre-populated with the item's current title,
+ * completion status checkbox, and group selector chips. Allows changing the title, toggling
+ * done/not-done, and moving the item to a different group.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun AddItemBottomSheet(
+fun EditItemBottomSheet(
+    item: ListItem,
     groups: List<GroupCardUiState>,
-    initialGroupId: String,
     onDismiss: () -> Unit,
-    onSave: (title: String, groupId: String) -> Unit,
+    onSave: (id: String, title: String, groupId: String, isDone: Boolean) -> Unit,
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
@@ -61,9 +65,9 @@ fun AddItemBottomSheet(
         containerColor = MaterialTheme.colorScheme.surfaceContainer,
         shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp),
     ) {
-        AddItemSheetContent(
+        EditItemSheetContent(
+            item = item,
             groups = groups,
-            initialGroupId = initialGroupId,
             onSave = onSave,
             requestFocus = true,
         )
@@ -71,18 +75,19 @@ fun AddItemBottomSheet(
 }
 
 /**
- * The inner content of the add-item sheet: title input, group selector chips,
- * and a save button. Extracted for preview support.
+ * The inner content of the edit-item sheet: pre-filled title input, done checkbox,
+ * group selector chips, and a save button. Extracted for preview support.
  */
 @Composable
-internal fun AddItemSheetContent(
+internal fun EditItemSheetContent(
+    item: ListItem,
     groups: List<GroupCardUiState>,
-    initialGroupId: String,
-    onSave: (title: String, groupId: String) -> Unit,
+    onSave: (id: String, title: String, groupId: String, isDone: Boolean) -> Unit,
     requestFocus: Boolean = false,
 ) {
-    var taskTitle by remember { mutableStateOf("") }
-    var selectedGroupId by remember { mutableStateOf(initialGroupId) }
+    var taskTitle by remember { mutableStateOf(item.title) }
+    var selectedGroupId by remember { mutableStateOf(item.listId) }
+    var isDone by remember { mutableStateOf(item.isDone) }
     val focusRequester = remember { FocusRequester() }
 
     if (requestFocus) {
@@ -99,7 +104,7 @@ internal fun AddItemSheetContent(
     ) {
         // Title
         Text(
-            text = "New Task",
+            text = "Edit Task",
             style = MaterialTheme.typography.headlineSmall.copy(
                 fontWeight = FontWeight.Bold,
             ),
@@ -108,22 +113,13 @@ internal fun AddItemSheetContent(
 
         Spacer(modifier = Modifier.height(20.dp))
 
-        // Subtitle
-        Text(
-            text = "What's on your mind?",
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-
-        Spacer(modifier = Modifier.height(8.dp))
-
         // Text field
         OutlinedTextField(
             value = taskTitle,
             onValueChange = { taskTitle = it },
             placeholder = {
                 Text(
-                    text = "I want to...",
+                    text = "Task name...",
                     color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
                 )
             },
@@ -139,12 +135,33 @@ internal fun AddItemSheetContent(
             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
             keyboardActions = KeyboardActions(onDone = {
                 if (taskTitle.isNotBlank()) {
-                    onSave(taskTitle.trim(), selectedGroupId)
+                    onSave(item.id, taskTitle.trim(), selectedGroupId, isDone)
                 }
             }),
         )
 
-        Spacer(modifier = Modifier.height(24.dp))
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Done status checkbox
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Checkbox(
+                checked = isDone,
+                onCheckedChange = { isDone = it },
+                colors = CheckboxDefaults.colors(
+                    checkedColor = ListCardColor.BLUE.color,
+                ),
+            )
+            Text(
+                text = if (isDone) "Completed" else "Not completed",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
 
         // Select list label
         Text(
@@ -182,7 +199,7 @@ internal fun AddItemSheetContent(
         Button(
             onClick = {
                 if (taskTitle.isNotBlank()) {
-                    onSave(taskTitle.trim(), selectedGroupId)
+                    onSave(item.id, taskTitle.trim(), selectedGroupId, isDone)
                 }
             },
             modifier = Modifier
@@ -195,7 +212,7 @@ internal fun AddItemSheetContent(
             enabled = taskTitle.isNotBlank(),
         ) {
             Text(
-                text = "Save Task",
+                text = "Save Changes",
                 style = MaterialTheme.typography.bodyLarge.copy(
                     fontWeight = FontWeight.SemiBold,
                 ),
@@ -222,13 +239,13 @@ private val previewGroups = listOf(
 
 @Composable
 @PreviewLightDark
-private fun AddItemSheetContentPreview() {
+private fun EditItemSheetContentPreview() {
     ListItTheme {
         Surface(color = MaterialTheme.colorScheme.surfaceContainer) {
-            AddItemSheetContent(
+            EditItemSheetContent(
+                item = ListItem(id = "1", title = "Buy groceries", isDone = false, listId = "2"),
                 groups = previewGroups,
-                initialGroupId = "1",
-                onSave = { _, _ -> },
+                onSave = { _, _, _, _ -> },
             )
         }
     }

--- a/app/src/main/java/com/example/listit/presentation/components/GroupCardView.kt
+++ b/app/src/main/java/com/example/listit/presentation/components/GroupCardView.kt
@@ -1,0 +1,191 @@
+package com.example.listit.presentation.components
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CheckboxDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.listit.domain.model.ListItem
+import com.example.listit.ui.theme.ListItTheme
+
+private const val MAX_PREVIEW_ITEMS = 3
+
+@Composable
+fun GroupCardView(
+    listName: String,
+    items: List<ListItem>,
+    style: ListCardStyle,
+    onAddItemClick: () -> Unit,
+    onViewAllClick: () -> Unit,
+    onCheckedClick: (id: String, isDone: Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val accentColor = style.accentColor.color
+
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainer,
+        ),
+    ) {
+        Column {
+            // Colored top accent bar
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(8.dp)
+                    .background(accentColor)
+            )
+
+            Column(modifier = Modifier.padding(16.dp)) {
+                // Header: icon + name + add button
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(
+                        imageVector = style.icon.imageVector,
+                        contentDescription = style.icon.label,
+                        tint = accentColor,
+                        modifier = Modifier.size(24.dp),
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = listName,
+                        style = MaterialTheme.typography.titleLarge.copy(
+                            fontWeight = FontWeight.Bold,
+                            fontSize = 20.sp,
+                        ),
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.weight(1f),
+                    )
+                    // Add button
+                    Box(
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(8.dp))
+                            .border(
+                                BorderStroke(1.5.dp, accentColor),
+                                RoundedCornerShape(8.dp),
+                            )
+                            .clickable { onAddItemClick() }
+                            .padding(horizontal = 8.dp, vertical = 4.dp),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Add,
+                            contentDescription = "Add item",
+                            tint = accentColor,
+                            modifier = Modifier.size(18.dp),
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                // Item list (limited preview)
+                val previewItems = items.take(MAX_PREVIEW_ITEMS)
+                previewItems.forEach { item ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Checkbox(
+                            checked = item.isDone,
+                            onCheckedChange = { onCheckedClick(item.id, item.isDone) },
+                            colors = CheckboxDefaults.colors(
+                                uncheckedColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                            ),
+                        )
+                        Text(
+                            text = item.title,
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                // "View all tasks >" link
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { onViewAllClick() },
+                    horizontalArrangement = Arrangement.Center,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = "View all tasks",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(18.dp),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+@PreviewLightDark
+private fun GroupCardViewPreview() {
+    ListItTheme {
+        GroupCardView(
+            listName = "Work",
+            items = listOf(
+                ListItem(id = "1", title = "Review PR for dashboard", isDone = false),
+                ListItem(id = "2", title = "Email Client about specs", isDone = false),
+                ListItem(id = "3", title = "Sync Meeting @ 2PM", isDone = false),
+                ListItem(id = "4", title = "Hidden fourth item", isDone = false),
+            ),
+            style = ListCardStyle(
+                icon = ListCardIcon.WORK,
+                accentColor = ListCardColor.BLUE,
+            ),
+            onAddItemClick = {},
+            onViewAllClick = {},
+            onCheckedClick = { _, _ -> },
+        )
+    }
+}

--- a/app/src/main/java/com/example/listit/presentation/components/GroupCardView.kt
+++ b/app/src/main/java/com/example/listit/presentation/components/GroupCardView.kt
@@ -30,7 +30,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.foundation.layout.Column
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -39,6 +41,11 @@ import com.example.listit.ui.theme.ListItTheme
 
 private const val MAX_PREVIEW_ITEMS = 3
 
+/**
+ * A card displaying a group's header (icon, name, add button) with a colored accent bar,
+ * a preview of up to 3 task items, and a "View all tasks" footer link.
+ * Shows a centered "Nothing here yet" message when the group has no items.
+ */
 @Composable
 fun GroupCardView(
     listName: String,
@@ -47,6 +54,7 @@ fun GroupCardView(
     onAddItemClick: () -> Unit,
     onViewAllClick: () -> Unit,
     onCheckedClick: (id: String, isDone: Boolean) -> Unit,
+    onItemClick: (ListItem) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val accentColor = style.accentColor.color
@@ -114,28 +122,28 @@ fun GroupCardView(
 
                 Spacer(modifier = Modifier.height(12.dp))
 
-                // Item list (limited preview)
-                val previewItems = items.take(MAX_PREVIEW_ITEMS)
-                previewItems.forEach { item ->
-                    Row(
+                if (items.isEmpty()) {
+                    // Empty state
+                    Box(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(vertical = 4.dp),
-                        verticalAlignment = Alignment.CenterVertically,
+                            .padding(vertical = 24.dp),
+                        contentAlignment = Alignment.Center,
                     ) {
-                        Checkbox(
-                            checked = item.isDone,
-                            onCheckedChange = { onCheckedClick(item.id, item.isDone) },
-                            colors = CheckboxDefaults.colors(
-                                uncheckedColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                            ),
-                        )
                         Text(
-                            text = item.title,
-                            style = MaterialTheme.typography.bodyLarge,
-                            color = MaterialTheme.colorScheme.onSurface,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
+                            text = "Nothing here yet",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                        )
+                    }
+                } else {
+                    // Item list (limited preview)
+                    val previewItems = items.take(MAX_PREVIEW_ITEMS)
+                    previewItems.forEach { item ->
+                        TaskItemRow(
+                            item = item,
+                            onCheckedClick = onCheckedClick,
+                            onItemClick = onItemClick,
                         )
                     }
                 }
@@ -167,6 +175,47 @@ fun GroupCardView(
     }
 }
 
+/**
+ * A single task row with a checkbox and title. Checked items display with
+ * strikethrough text and dimmed color. Tapping the row opens the edit sheet.
+ */
+@Composable
+fun TaskItemRow(
+    item: ListItem,
+    onCheckedClick: (id: String, isDone: Boolean) -> Unit,
+    onItemClick: (ListItem) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable { onItemClick(item) }
+            .padding(vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Checkbox(
+            checked = item.isDone,
+            onCheckedChange = { onCheckedClick(item.id, item.isDone) },
+            colors = CheckboxDefaults.colors(
+                uncheckedColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            ),
+        )
+        Text(
+            text = item.title,
+            style = MaterialTheme.typography.bodyLarge.copy(
+                textDecoration = if (item.isDone) TextDecoration.LineThrough else TextDecoration.None,
+            ),
+            color = if (item.isDone) {
+                MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f)
+            } else {
+                MaterialTheme.colorScheme.onSurface
+            },
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
 @Composable
 @PreviewLightDark
 private fun GroupCardViewPreview() {
@@ -176,7 +225,7 @@ private fun GroupCardViewPreview() {
             items = listOf(
                 ListItem(id = "1", title = "Review PR for dashboard", isDone = false),
                 ListItem(id = "2", title = "Email Client about specs", isDone = false),
-                ListItem(id = "3", title = "Sync Meeting @ 2PM", isDone = false),
+                ListItem(id = "3", title = "Sync Meeting @ 2PM", isDone = true),
                 ListItem(id = "4", title = "Hidden fourth item", isDone = false),
             ),
             style = ListCardStyle(
@@ -186,6 +235,26 @@ private fun GroupCardViewPreview() {
             onAddItemClick = {},
             onViewAllClick = {},
             onCheckedClick = { _, _ -> },
+            onItemClick = {},
         )
+    }
+}
+
+@Composable
+@PreviewLightDark
+private fun TaskItemRowPreview() {
+    ListItTheme {
+        Column {
+            TaskItemRow(
+                item = ListItem(id = "1", title = "Unchecked task", isDone = false),
+                onCheckedClick = { _, _ -> },
+                onItemClick = {},
+            )
+            TaskItemRow(
+                item = ListItem(id = "2", title = "Completed task", isDone = true),
+                onCheckedClick = { _, _ -> },
+                onItemClick = {},
+            )
+        }
     }
 }

--- a/app/src/main/java/com/example/listit/presentation/components/GroupChip.kt
+++ b/app/src/main/java/com/example/listit/presentation/components/GroupChip.kt
@@ -1,0 +1,94 @@
+package com.example.listit.presentation.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import com.example.listit.ui.theme.ListItTheme
+
+/**
+ * A selectable chip representing a group/list, showing the group's icon and name
+ * with a filled accent-color background when selected.
+ */
+@Composable
+fun GroupChip(
+    name: String,
+    icon: ListCardIcon,
+    accentColor: Color,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+) {
+    val backgroundColor = if (isSelected) {
+        accentColor
+    } else {
+        MaterialTheme.colorScheme.surfaceContainerHighest
+    }
+    val contentColor = if (isSelected) {
+        Color.White
+    } else {
+        MaterialTheme.colorScheme.onSurfaceVariant
+    }
+
+    Row(
+        modifier = Modifier
+            .clip(RoundedCornerShape(12.dp))
+            .background(backgroundColor)
+            .clickable { onClick() }
+            .padding(horizontal = 16.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = icon.imageVector,
+            contentDescription = null,
+            tint = contentColor,
+            modifier = Modifier.size(18.dp),
+        )
+        Spacer(modifier = Modifier.width(6.dp))
+        Text(
+            text = name,
+            style = MaterialTheme.typography.bodyMedium.copy(
+                fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal,
+            ),
+            color = contentColor,
+        )
+    }
+}
+
+@Composable
+@PreviewLightDark
+private fun GroupChipSelectedPreview() {
+    ListItTheme {
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            GroupChip(
+                name = "Work",
+                icon = ListCardIcon.WORK,
+                accentColor = ListCardColor.BLUE.color,
+                isSelected = true,
+                onClick = {},
+            )
+            GroupChip(
+                name = "Shopping",
+                icon = ListCardIcon.SHOPPING,
+                accentColor = ListCardColor.GREEN.color,
+                isSelected = false,
+                onClick = {},
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/listit/presentation/components/ListCardConfig.kt
+++ b/app/src/main/java/com/example/listit/presentation/components/ListCardConfig.kt
@@ -1,0 +1,53 @@
+package com.example.listit.presentation.components
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Build
+import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.ShoppingCart
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.ThumbUp
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+
+data class ListCardStyle(
+    val icon: ListCardIcon,
+    val accentColor: ListCardColor,
+)
+
+enum class ListCardIcon(val imageVector: ImageVector, val label: String) {
+    WORK(Icons.Filled.Build, "Work"),
+    HOME(Icons.Filled.Home, "Home"),
+    SHOPPING(Icons.Filled.ShoppingCart, "Shopping"),
+    STAR(Icons.Filled.Star, "Star"),
+    HEART(Icons.Filled.Favorite, "Heart"),
+    PERSON(Icons.Filled.Person, "Personal"),
+    CALENDAR(Icons.Filled.DateRange, "Calendar"),
+    THUMBS_UP(Icons.Filled.ThumbUp, "Thumbs Up"),
+}
+
+enum class ListCardColor(val color: Color, val label: String) {
+    BLUE(Color(0xFF5B8DEF), "Blue"),
+    RED(Color(0xFFEF5B5B), "Red"),
+    GREEN(Color(0xFF5BEF8D), "Green"),
+    ORANGE(Color(0xFFEFA85B), "Orange"),
+    PURPLE(Color(0xFFAB5BEF), "Purple"),
+    TEAL(Color(0xFF5BEFEF), "Teal"),
+    PINK(Color(0xFFEF5BBF), "Pink"),
+    YELLOW(Color(0xFFEFD95B), "Yellow"),
+}
+
+fun randomListCardStyle(usedStyles: List<ListCardStyle> = emptyList()): ListCardStyle {
+    val usedIcons = usedStyles.map { it.icon }.toSet()
+    val usedColors = usedStyles.map { it.accentColor }.toSet()
+
+    val availableIcons = ListCardIcon.entries.filter { it !in usedIcons }
+    val availableColors = ListCardColor.entries.filter { it !in usedColors }
+
+    val icon = availableIcons.randomOrNull() ?: ListCardIcon.entries.random()
+    val color = availableColors.randomOrNull() ?: ListCardColor.entries.random()
+
+    return ListCardStyle(icon = icon, accentColor = color)
+}

--- a/app/src/main/java/com/example/listit/presentation/components/ListItemView.kt
+++ b/app/src/main/java/com/example/listit/presentation/components/ListItemView.kt
@@ -16,8 +16,15 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.foundation.layout.Column
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
+import com.example.listit.ui.theme.ListItTheme
 
+/**
+ * An outlined card displaying a single list item with a checkbox and title.
+ * The card border turns gray and text gets strikethrough when the item is done.
+ */
 @Composable
 fun ListItemView(
     title: String,
@@ -49,6 +56,27 @@ fun ListItemView(
                 style = TextStyle(
                     textDecoration = if (isDone) TextDecoration.LineThrough else TextDecoration.None
                 ),
+            )
+        }
+    }
+}
+
+@Composable
+@PreviewLightDark
+private fun ListItemViewPreview() {
+    ListItTheme {
+        Column {
+            ListItemView(
+                title = "Buy groceries",
+                isDone = false,
+                onCheckedClick = {},
+                onItemClick = {},
+            )
+            ListItemView(
+                title = "Send email",
+                isDone = true,
+                onCheckedClick = {},
+                onItemClick = {},
             )
         }
     }

--- a/app/src/main/java/com/example/listit/presentation/edit/EditScreen.kt
+++ b/app/src/main/java/com/example/listit/presentation/edit/EditScreen.kt
@@ -17,6 +17,11 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.example.listit.presentation.navigation.ScreenNavigation
 
+/**
+ * A full-screen item detail/edit view with a text field for editing the title,
+ * a display of the current title, a delete button with confirmation dialog,
+ * and done/not-done status indicator.
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun EditScreen(

--- a/app/src/main/java/com/example/listit/presentation/home/GroupCardUiState.kt
+++ b/app/src/main/java/com/example/listit/presentation/home/GroupCardUiState.kt
@@ -1,0 +1,11 @@
+package com.example.listit.presentation.home
+
+import com.example.listit.domain.model.ListItem
+import com.example.listit.presentation.components.ListCardStyle
+
+data class GroupCardUiState(
+    val groupId: String,
+    val groupName: String,
+    val items: List<ListItem>,
+    val style: ListCardStyle,
+)

--- a/app/src/main/java/com/example/listit/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/listit/presentation/home/HomeScreen.kt
@@ -15,11 +15,17 @@ import com.example.listit.presentation.components.ListCardIcon
 import com.example.listit.presentation.components.ListCardStyle
 import com.example.listit.ui.theme.ListItTheme
 
+/**
+ * The main home screen displaying a vertically scrollable list of group cards.
+ * Each card shows a preview of its tasks and links to the full group view.
+ */
 @Composable
 fun HomeView(
     viewModel: HomeViewModel,
     modifier: Modifier = Modifier,
     onAddItemClick: (groupId: String) -> Unit = {},
+    onViewAllClick: (groupId: String) -> Unit = {},
+    onItemClick: (ListItem) -> Unit = {},
 ) {
     val groupCards by viewModel.groupCards.collectAsStateWithLifecycle()
 
@@ -27,10 +33,11 @@ fun HomeView(
         groupCards = groupCards,
         modifier = modifier,
         onAddItemClick = onAddItemClick,
-        onViewAllClick = { /* future work */ },
+        onViewAllClick = onViewAllClick,
         onCheckedClick = { id, isDone ->
             viewModel.changeItemCheckStatus(id, checked = isDone.not())
         },
+        onItemClick = onItemClick,
     )
 }
 
@@ -41,6 +48,7 @@ private fun HomeViewInternal(
     onAddItemClick: (groupId: String) -> Unit,
     onViewAllClick: (groupId: String) -> Unit,
     onCheckedClick: (id: String, isDone: Boolean) -> Unit,
+    onItemClick: (ListItem) -> Unit,
 ) {
     LazyColumn(modifier = modifier.fillMaxSize()) {
         items(items = groupCards, key = { it.groupId }) { card ->
@@ -51,6 +59,7 @@ private fun HomeViewInternal(
                 onAddItemClick = { onAddItemClick(card.groupId) },
                 onViewAllClick = { onViewAllClick(card.groupId) },
                 onCheckedClick = onCheckedClick,
+                onItemClick = onItemClick,
             )
         }
     }
@@ -90,6 +99,7 @@ fun HomeViewPreview() {
             onAddItemClick = {},
             onViewAllClick = {},
             onCheckedClick = { _, _ -> },
+            onItemClick = {},
         )
     }
 }

--- a/app/src/main/java/com/example/listit/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/listit/presentation/home/HomeScreen.kt
@@ -1,111 +1,95 @@
 package com.example.listit.presentation.home
 
-import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.navigation.NavController
 import com.example.listit.domain.model.ListItem
-import com.example.listit.presentation.navigation.ScreenNavigation
+import com.example.listit.presentation.components.GroupCardView
+import com.example.listit.presentation.components.ListCardColor
+import com.example.listit.presentation.components.ListCardIcon
+import com.example.listit.presentation.components.ListCardStyle
 import com.example.listit.ui.theme.ListItTheme
-import com.example.listit.presentation.components.ListItemView
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
-fun MainListView(
+fun HomeView(
     viewModel: HomeViewModel,
-    navController: NavController,
     modifier: Modifier = Modifier,
+    onAddItemClick: (groupId: String) -> Unit = {},
 ) {
-    val listItems by viewModel.observeItems.collectAsStateWithLifecycle()
+    val groupCards by viewModel.groupCards.collectAsStateWithLifecycle()
 
-    MainListViewInternal(
-        listItems = listItems,
+    HomeViewInternal(
+        groupCards = groupCards,
         modifier = modifier,
-        onItemClick = { id: String, title: String, isDone: Boolean ->
-            navController.navigate(
-                route = ScreenNavigation.Edit.passIdAndTitle(
-                    id = id,
-                    title = title,
-                    isDone = isDone,
-                )
-            )
-        },
-        onCheckedClick = { id: String, isDone: Boolean ->
+        onAddItemClick = onAddItemClick,
+        onViewAllClick = { /* future work */ },
+        onCheckedClick = { id, isDone ->
             viewModel.changeItemCheckStatus(id, checked = isDone.not())
         },
     )
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
-private fun MainListViewInternal(
+private fun HomeViewInternal(
+    groupCards: List<GroupCardUiState>,
     modifier: Modifier = Modifier,
-    listItems: List<ListItem>,
-    onItemClick: (id: String, title: String, isDone: Boolean) -> Unit,
+    onAddItemClick: (groupId: String) -> Unit,
+    onViewAllClick: (groupId: String) -> Unit,
     onCheckedClick: (id: String, isDone: Boolean) -> Unit,
 ) {
-    var onlyShowDone by remember { mutableStateOf(false) }
-
     LazyColumn(modifier = modifier.fillMaxSize()) {
-        items(items = listItems.filter {
-            it.isDone == onlyShowDone
-        }) { item: ListItem ->
-            ListItemView(
-                title = item.title,
-                isDone = item.isDone,
-                onCheckedClick = {
-                    onCheckedClick(
-                        item.id,
-                        item.isDone,
-                    )
-                },
-                onItemClick = {
-                    onItemClick(
-                        item.id,
-                        item.title,
-                        item.isDone,
-                    )
-                }
+        items(items = groupCards, key = { it.groupId }) { card ->
+            GroupCardView(
+                listName = card.groupName,
+                items = card.items,
+                style = card.style,
+                onAddItemClick = { onAddItemClick(card.groupId) },
+                onViewAllClick = { onViewAllClick(card.groupId) },
+                onCheckedClick = onCheckedClick,
             )
-        }
-        item {
-            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
-                TextButton(onClick = { onlyShowDone = !onlyShowDone }) {
-                    Text(text = if (onlyShowDone) "Show not completed" else "Show completed")
-                }
-            }
         }
     }
 }
 
 @Composable
 @PreviewLightDark
-fun MainListViewPreview() {
+fun HomeViewPreview() {
     ListItTheme {
-        MainListViewInternal(
-            listItems = listOf(
-                ListItem(id = "1", title = "Buy groceries", isDone = false),
-                ListItem(id = "2", title = "Walk the dog", isDone = true),
-                ListItem(id = "3", title = "Finish homework", isDone = false),
-                ListItem(id = "4", title = "Call mom", isDone = false),
-                ListItem(id = "5", title = "Read a book", isDone = true),
+        HomeViewInternal(
+            groupCards = listOf(
+                GroupCardUiState(
+                    groupId = "1",
+                    groupName = "Work",
+                    items = listOf(
+                        ListItem(id = "1", title = "Review PR", isDone = false),
+                        ListItem(id = "2", title = "Email client", isDone = true),
+                    ),
+                    style = ListCardStyle(
+                        icon = ListCardIcon.WORK,
+                        accentColor = ListCardColor.BLUE,
+                    ),
+                ),
+                GroupCardUiState(
+                    groupId = "2",
+                    groupName = "Shopping",
+                    items = listOf(
+                        ListItem(id = "3", title = "Buy groceries", isDone = false),
+                        ListItem(id = "4", title = "Pick up dry cleaning", isDone = false),
+                    ),
+                    style = ListCardStyle(
+                        icon = ListCardIcon.SHOPPING,
+                        accentColor = ListCardColor.GREEN,
+                    ),
+                ),
             ),
-            onItemClick = { _, _, _ -> },
-            onCheckedClick = { _, _ -> }
+            onAddItemClick = {},
+            onViewAllClick = {},
+            onCheckedClick = { _, _ -> },
         )
     }
 }

--- a/app/src/main/java/com/example/listit/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/listit/presentation/home/HomeViewModel.kt
@@ -7,7 +7,9 @@ import com.example.listit.domain.usecase.AddListUseCase
 import com.example.listit.domain.usecase.DeleteItemUseCase
 import com.example.listit.domain.usecase.ObserveGroupsUseCase
 import com.example.listit.domain.usecase.ObserveItemsUseCase
+import com.example.listit.domain.usecase.MoveItemUseCase
 import com.example.listit.domain.usecase.UpdateItemStatusUseCase
+import com.example.listit.domain.usecase.UpdateItemTitleUseCase
 import com.example.listit.presentation.components.ListCardColor
 import com.example.listit.presentation.components.ListCardIcon
 import com.example.listit.presentation.components.ListCardStyle
@@ -28,6 +30,8 @@ class HomeViewModel @Inject constructor(
     private val addListUseCase: AddListUseCase,
     private val deleteItemUseCase: DeleteItemUseCase,
     private val updateItemStatusUseCase: UpdateItemStatusUseCase,
+    private val updateItemTitleUseCase: UpdateItemTitleUseCase,
+    private val moveItemUseCase: MoveItemUseCase,
 ) : ViewModel() {
 
     val groupCards: StateFlow<List<GroupCardUiState>> = combine(
@@ -39,14 +43,15 @@ class HomeViewModel @Inject constructor(
         val colors = ListCardColor.entries
 
         groups.sortedBy { it.id }
-            .mapIndexed { index, group ->
+            .map { group ->
                 GroupCardUiState(
                     groupId = group.id,
                     groupName = group.name,
-                    items = itemsByListId[group.id].orEmpty(),
+                    items = itemsByListId[group.id].orEmpty()
+                        .sortedBy { it.isDone },
                     style = ListCardStyle(
-                        icon = icons[index % icons.size],
-                        accentColor = colors[index % colors.size],
+                        icon = icons[group.colorIndex % icons.size],
+                        accentColor = colors[group.colorIndex % colors.size],
                     ),
                 )
             }
@@ -77,6 +82,14 @@ class HomeViewModel @Inject constructor(
     fun changeItemCheckStatus(id: String, checked: Boolean) {
         viewModelScope.launch(Dispatchers.IO) {
             updateItemStatusUseCase(id = id, isDone = checked)
+        }
+    }
+
+    fun updateItem(id: String, title: String, groupId: String, isDone: Boolean) {
+        viewModelScope.launch(Dispatchers.IO) {
+            updateItemTitleUseCase(id = id, title = title)
+            updateItemStatusUseCase(id = id, isDone = isDone)
+            moveItemUseCase(id = id, targetListId = groupId)
         }
     }
 }

--- a/app/src/main/java/com/example/listit/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/listit/presentation/home/HomeViewModel.kt
@@ -2,15 +2,20 @@ package com.example.listit.presentation.home
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.listit.domain.model.ListItem
 import com.example.listit.domain.usecase.AddItemUseCase
+import com.example.listit.domain.usecase.AddListUseCase
 import com.example.listit.domain.usecase.DeleteItemUseCase
+import com.example.listit.domain.usecase.ObserveGroupsUseCase
 import com.example.listit.domain.usecase.ObserveItemsUseCase
 import com.example.listit.domain.usecase.UpdateItemStatusUseCase
+import com.example.listit.presentation.components.ListCardColor
+import com.example.listit.presentation.components.ListCardIcon
+import com.example.listit.presentation.components.ListCardStyle
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -18,21 +23,48 @@ import javax.inject.Inject
 @HiltViewModel
 class HomeViewModel @Inject constructor(
     observeItemsUseCase: ObserveItemsUseCase,
+    observeGroupsUseCase: ObserveGroupsUseCase,
     private val addItemUseCase: AddItemUseCase,
+    private val addListUseCase: AddListUseCase,
     private val deleteItemUseCase: DeleteItemUseCase,
     private val updateItemStatusUseCase: UpdateItemStatusUseCase,
 ) : ViewModel() {
 
-    val observeItems: StateFlow<List<ListItem>> = observeItemsUseCase()
-        .stateIn(
-            scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(5000),
-            initialValue = emptyList()
-        )
+    val groupCards: StateFlow<List<GroupCardUiState>> = combine(
+        observeGroupsUseCase(),
+        observeItemsUseCase(),
+    ) { groups, items ->
+        val itemsByListId = items.groupBy { it.listId }
+        val icons = ListCardIcon.entries
+        val colors = ListCardColor.entries
 
-    fun addItem(title: String) {
+        groups.sortedBy { it.id }
+            .mapIndexed { index, group ->
+                GroupCardUiState(
+                    groupId = group.id,
+                    groupName = group.name,
+                    items = itemsByListId[group.id].orEmpty(),
+                    style = ListCardStyle(
+                        icon = icons[index % icons.size],
+                        accentColor = colors[index % colors.size],
+                    ),
+                )
+            }
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = emptyList(),
+    )
+
+    fun addItem(title: String, listId: String) {
         viewModelScope.launch(Dispatchers.IO) {
-            addItemUseCase(title)
+            addItemUseCase(title = title, listId = listId)
+        }
+    }
+
+    fun addGroup(name: String) {
+        viewModelScope.launch(Dispatchers.IO) {
+            addListUseCase(name)
         }
     }
 

--- a/app/src/main/java/com/example/listit/presentation/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/listit/presentation/navigation/NavGraph.kt
@@ -9,6 +9,7 @@ import androidx.navigation.navArgument
 import com.example.listit.presentation.edit.EditScreen
 import com.example.listit.presentation.root.RootScreen
 import com.example.listit.presentation.settings.SettingsScreen
+import com.example.listit.presentation.viewall.ViewAllScreen
 
 @Composable
 fun SetupNavGraph(
@@ -34,6 +35,16 @@ fun SetupNavGraph(
             )
         ) {
             EditScreen(
+                navController = navController,
+            )
+        }
+        composable(
+            route = ScreenNavigation.ViewAll.route,
+            arguments = listOf(
+                navArgument(name = VIEW_ALL_ARG_GROUP_ID) { type = NavType.StringType },
+            )
+        ) {
+            ViewAllScreen(
                 navController = navController,
             )
         }

--- a/app/src/main/java/com/example/listit/presentation/navigation/ScreenNavigation.kt
+++ b/app/src/main/java/com/example/listit/presentation/navigation/ScreenNavigation.kt
@@ -3,6 +3,7 @@ package com.example.listit.presentation.navigation
 const val EDIT_ARGUMENT_KEY = "id"
 const val EDIT_ARGUMENT_KEY2 = "title"
 const val EDIT_ARGUMENT_KEY3 = "isDone"
+const val VIEW_ALL_ARG_GROUP_ID = "groupId"
 
 sealed class ScreenNavigation(val route: String) {
 
@@ -12,6 +13,10 @@ sealed class ScreenNavigation(val route: String) {
         fun passIdAndTitle(id: String, title: String, isDone: Boolean,): String {
             return "edit_screen/$id/$title/$isDone"
         }
+    }
+
+    object ViewAll : ScreenNavigation(route = "view_all/{$VIEW_ALL_ARG_GROUP_ID}") {
+        fun createRoute(groupId: String): String = "view_all/$groupId"
     }
 
     object Settings : ScreenNavigation(route = "settings_screen")

--- a/app/src/main/java/com/example/listit/presentation/root/RootScreen.kt
+++ b/app/src/main/java/com/example/listit/presentation/root/RootScreen.kt
@@ -16,10 +16,15 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
-import com.example.listit.presentation.home.MainListView
+import com.example.listit.presentation.components.AddItemBottomSheet
+import com.example.listit.presentation.home.HomeView
 import com.example.listit.presentation.home.HomeViewModel
 import com.example.listit.presentation.navigation.ScreenNavigation
 
@@ -29,11 +34,15 @@ fun RootScreen(
     navController: NavController,
 ) {
     var promptAddNewItemUi by remember { mutableStateOf(false) }
+    var addItemToGroupId by remember { mutableStateOf<String?>(null) }
     val viewModel: HomeViewModel = hiltViewModel()
+    val groupCards by viewModel.groupCards.collectAsStateWithLifecycle()
+
     BackPressedHandler(
         onBackPressed = { promptAddNewItemUi = false },
         isEnabled = promptAddNewItemUi
     )
+
     Scaffold(
         floatingActionButtonPosition = FabPosition.End,
         floatingActionButton = {
@@ -75,26 +84,39 @@ fun RootScreen(
             if (promptAddNewItemUi) {
                 BottomAppBar() {
                     // TODO: close this prompt if back if pressed.
-                    AddNewItemUi(onAddItem = { title ->
-                        viewModel.addItem(title)
-                    }, finishedAddingItem = {
+                    AddNewGroupUi(onAddGroup = { name ->
+                        viewModel.addGroup(name)
+                    }, finishedAdding = {
                         promptAddNewItemUi = false
                     })
                 }
             }
         }
     ) { innerPaddingValues ->
-        MainListView(
+        HomeView(
             modifier = Modifier.padding(innerPaddingValues),
             viewModel = viewModel,
-            navController = navController,
+            onAddItemClick = { groupId -> addItemToGroupId = groupId },
+        )
+    }
+
+    // Add Item Bottom Sheet
+    addItemToGroupId?.let { groupId ->
+        AddItemBottomSheet(
+            groups = groupCards,
+            initialGroupId = groupId,
+            onDismiss = { addItemToGroupId = null },
+            onSave = { title, selectedGroupId ->
+                viewModel.addItem(title = title, listId = selectedGroupId)
+                addItemToGroupId = null
+            },
         )
     }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun AddNewItemUi(onAddItem: (String) -> Unit, finishedAddingItem: () -> Unit) {
+fun AddNewGroupUi(onAddGroup: (String) -> Unit, finishedAdding: () -> Unit) {
     var textFieldValue by remember {
         mutableStateOf("")
     }
@@ -113,16 +135,24 @@ fun AddNewItemUi(onAddItem: (String) -> Unit, finishedAddingItem: () -> Unit) {
                         start = 8.dp, end = 8.dp, top = 8.dp, bottom = 8.dp
                     )
                 ),
-            placeholder = { Text(text = "enter new item") },
+            placeholder = { Text(text = "enter new group name") },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+            keyboardActions = KeyboardActions(onDone = {
+                if (textFieldValue.isNotEmpty()) {
+                    onAddGroup(textFieldValue)
+                    finishedAdding()
+                }
+            }),
             trailingIcon = {
                 IconButton(enabled = textFieldValue.isNotEmpty(),
                     onClick = {
-                        onAddItem(textFieldValue)
-                        finishedAddingItem()
+                        onAddGroup(textFieldValue)
+                        finishedAdding()
                     }) {
                     Icon(
                         imageVector = Icons.Filled.Send,
-                        contentDescription = "Add a task to the list",
+                        contentDescription = "Add a new group",
                     )
                 }
             })

--- a/app/src/main/java/com/example/listit/presentation/root/RootScreen.kt
+++ b/app/src/main/java/com/example/listit/presentation/root/RootScreen.kt
@@ -19,15 +19,24 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
+import com.example.listit.domain.model.ListItem
 import com.example.listit.presentation.components.AddItemBottomSheet
+import com.example.listit.presentation.components.EditItemBottomSheet
 import com.example.listit.presentation.home.HomeView
 import com.example.listit.presentation.home.HomeViewModel
 import com.example.listit.presentation.navigation.ScreenNavigation
+import com.example.listit.ui.theme.ListItTheme
 
+/**
+ * The root scaffold screen containing the top app bar, FAB for adding groups,
+ * bottom bar for group creation input, and the home view with group cards.
+ * Also manages the add-item and edit-item bottom sheet overlays.
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RootScreen(
@@ -35,6 +44,7 @@ fun RootScreen(
 ) {
     var promptAddNewItemUi by remember { mutableStateOf(false) }
     var addItemToGroupId by remember { mutableStateOf<String?>(null) }
+    var editingItem by remember { mutableStateOf<ListItem?>(null) }
     val viewModel: HomeViewModel = hiltViewModel()
     val groupCards by viewModel.groupCards.collectAsStateWithLifecycle()
 
@@ -83,7 +93,6 @@ fun RootScreen(
         bottomBar = {
             if (promptAddNewItemUi) {
                 BottomAppBar() {
-                    // TODO: close this prompt if back if pressed.
                     AddNewGroupUi(onAddGroup = { name ->
                         viewModel.addGroup(name)
                     }, finishedAdding = {
@@ -97,6 +106,10 @@ fun RootScreen(
             modifier = Modifier.padding(innerPaddingValues),
             viewModel = viewModel,
             onAddItemClick = { groupId -> addItemToGroupId = groupId },
+            onViewAllClick = { groupId ->
+                navController.navigate(ScreenNavigation.ViewAll.createRoute(groupId))
+            },
+            onItemClick = { item -> editingItem = item },
         )
     }
 
@@ -112,8 +125,25 @@ fun RootScreen(
             },
         )
     }
+
+    // Edit Item Bottom Sheet
+    editingItem?.let { item ->
+        EditItemBottomSheet(
+            item = item,
+            groups = groupCards,
+            onDismiss = { editingItem = null },
+            onSave = { id, title, groupId, isDone ->
+                viewModel.updateItem(id, title, groupId, isDone)
+                editingItem = null
+            },
+        )
+    }
 }
 
+/**
+ * A bottom bar input field for creating a new group. Shows a text field with a send button;
+ * pressing Done on the keyboard or tapping send creates the group and dismisses the UI.
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AddNewGroupUi(onAddGroup: (String) -> Unit, finishedAdding: () -> Unit) {
@@ -160,6 +190,10 @@ fun AddNewGroupUi(onAddGroup: (String) -> Unit, finishedAdding: () -> Unit) {
     }
 }
 
+/**
+ * A utility composable that intercepts the system back press when enabled,
+ * invoking the provided callback instead of default back navigation.
+ */
 @Composable
 fun BackPressedHandler(
     backPressedDispatcher: OnBackPressedDispatcher? = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher,
@@ -185,5 +219,16 @@ fun BackPressedHandler(
         onDispose {
             backCallBack.remove()
         }
+    }
+}
+
+@Composable
+@PreviewLightDark
+private fun AddNewGroupUiPreview() {
+    ListItTheme {
+        AddNewGroupUi(
+            onAddGroup = {},
+            finishedAdding = {},
+        )
     }
 }

--- a/app/src/main/java/com/example/listit/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/example/listit/presentation/settings/SettingsScreen.kt
@@ -7,9 +7,15 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.example.listit.ui.theme.ListItTheme
 
+/**
+ * Placeholder settings screen with static text content.
+ * Will house app-level configuration options in the future.
+ */
 @Composable
 fun SettingsScreen() {
     Column {
@@ -25,5 +31,13 @@ fun SettingsScreen() {
                 .height(1.dp)
                 .fillMaxWidth()
         )
+    }
+}
+
+@Composable
+@PreviewLightDark
+private fun SettingsScreenPreview() {
+    ListItTheme {
+        SettingsScreen()
     }
 }

--- a/app/src/main/java/com/example/listit/presentation/viewall/ViewAllScreen.kt
+++ b/app/src/main/java/com/example/listit/presentation/viewall/ViewAllScreen.kt
@@ -1,0 +1,201 @@
+package com.example.listit.presentation.viewall
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.FabPosition
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavController
+import com.example.listit.domain.model.ListItem
+import com.example.listit.presentation.components.AddItemBottomSheet
+import com.example.listit.presentation.components.EditItemBottomSheet
+import com.example.listit.presentation.components.TaskItemRow
+
+/**
+ * Full-screen view of all tasks in a single group. Features a large colored header block
+ * with the group's accent color, icon, name, settings gear, and a FAB for adding items.
+ * Below the header is a scrollable list of all items with check/edit support.
+ */
+@Composable
+fun ViewAllScreen(
+    navController: NavController,
+    viewModel: ViewAllViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    var showAddSheet by remember { mutableStateOf(false) }
+    var editingItem by remember { mutableStateOf<ListItem?>(null) }
+
+    Scaffold(
+        containerColor = MaterialTheme.colorScheme.background,
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = { showAddSheet = true },
+                containerColor = uiState.style.accentColor.color,
+                contentColor = Color.White,
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Add,
+                    contentDescription = "Add item",
+                )
+            }
+        },
+        floatingActionButtonPosition = FabPosition.End,
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+        ) {
+            // Colored header block
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(uiState.style.accentColor.color)
+                    .windowInsetsPadding(WindowInsets.statusBars)
+                    .padding(bottom = 24.dp),
+            ) {
+                // Single row: back arrow, group icon + name, settings gear
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = 4.dp, end = 4.dp, top = 8.dp),
+                    verticalAlignment = Alignment.Top,
+                ) {
+                    IconButton(onClick = { navController.navigateUp() }) {
+                        Icon(
+                            imageVector = Icons.Filled.ArrowBack,
+                            contentDescription = "Back",
+                            tint = Color.White,
+                        )
+                    }
+
+                    // Group icon + name - expands up to 2 lines
+                    Row(
+                        modifier = Modifier
+                            .weight(1f)
+                            .padding(horizontal = 4.dp, vertical = 8.dp),
+                        verticalAlignment = Alignment.Top,
+                    ) {
+                        Icon(
+                            imageVector = uiState.style.icon.imageVector,
+                            contentDescription = uiState.style.icon.label,
+                            tint = Color.White,
+                            modifier = Modifier.size(32.dp),
+                        )
+                        Spacer(modifier = Modifier.width(12.dp))
+                        Text(
+                            text = uiState.groupName,
+                            style = MaterialTheme.typography.headlineMedium.copy(
+                                fontWeight = FontWeight.Bold,
+                                fontSize = 28.sp,
+                            ),
+                            color = Color.White,
+                            maxLines = 2,
+                        )
+                    }
+
+                    IconButton(onClick = { /* future: group settings */ }) {
+                        Icon(
+                            imageVector = Icons.Filled.Settings,
+                            contentDescription = "Group settings",
+                            tint = Color.White,
+                        )
+                    }
+                }
+            }
+
+            // Items list
+            if (uiState.items.isEmpty()) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 48.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = "Nothing here yet",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                    )
+                }
+            } else {
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                ) {
+                    items(items = uiState.items, key = { it.id }) { item ->
+                        TaskItemRow(
+                            item = item,
+                            onCheckedClick = { id, isDone ->
+                                viewModel.changeItemCheckStatus(id, checked = isDone.not())
+                            },
+                            onItemClick = { editingItem = it },
+                            modifier = Modifier.padding(vertical = 2.dp),
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    // Add Item Bottom Sheet
+    if (showAddSheet) {
+        AddItemBottomSheet(
+            groups = uiState.allGroups,
+            initialGroupId = uiState.groupId,
+            onDismiss = { showAddSheet = false },
+            onSave = { title, selectedGroupId ->
+                viewModel.addItem(title)
+                showAddSheet = false
+            },
+        )
+    }
+
+    // Edit Item Bottom Sheet
+    editingItem?.let { item ->
+        EditItemBottomSheet(
+            item = item,
+            groups = uiState.allGroups,
+            onDismiss = { editingItem = null },
+            onSave = { id, title, groupId, isDone ->
+                viewModel.updateItem(id, title, groupId, isDone)
+                editingItem = null
+            },
+        )
+    }
+}

--- a/app/src/main/java/com/example/listit/presentation/viewall/ViewAllViewModel.kt
+++ b/app/src/main/java/com/example/listit/presentation/viewall/ViewAllViewModel.kt
@@ -1,0 +1,116 @@
+package com.example.listit.presentation.viewall
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.listit.domain.model.ListItem
+import com.example.listit.domain.usecase.AddItemUseCase
+import com.example.listit.domain.usecase.DeleteItemUseCase
+import com.example.listit.domain.usecase.MoveItemUseCase
+import com.example.listit.domain.usecase.ObserveGroupsUseCase
+import com.example.listit.domain.usecase.ObserveItemsByListUseCase
+import com.example.listit.domain.usecase.UpdateItemStatusUseCase
+import com.example.listit.domain.usecase.UpdateItemTitleUseCase
+import com.example.listit.presentation.components.ListCardColor
+import com.example.listit.presentation.components.ListCardIcon
+import com.example.listit.presentation.components.ListCardStyle
+import com.example.listit.presentation.home.GroupCardUiState
+import com.example.listit.presentation.navigation.VIEW_ALL_ARG_GROUP_ID
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class ViewAllUiState(
+    val groupId: String = "",
+    val groupName: String = "",
+    val items: List<ListItem> = emptyList(),
+    val style: ListCardStyle = ListCardStyle(
+        icon = ListCardIcon.WORK,
+        accentColor = ListCardColor.BLUE,
+    ),
+    val allGroups: List<GroupCardUiState> = emptyList(),
+)
+
+@HiltViewModel
+class ViewAllViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    observeItemsByListUseCase: ObserveItemsByListUseCase,
+    observeGroupsUseCase: ObserveGroupsUseCase,
+    private val addItemUseCase: AddItemUseCase,
+    private val updateItemStatusUseCase: UpdateItemStatusUseCase,
+    private val updateItemTitleUseCase: UpdateItemTitleUseCase,
+    private val moveItemUseCase: MoveItemUseCase,
+    private val deleteItemUseCase: DeleteItemUseCase,
+) : ViewModel() {
+
+    private val groupId: String = savedStateHandle.get<String>(VIEW_ALL_ARG_GROUP_ID) ?: ""
+
+    val uiState: StateFlow<ViewAllUiState> = combine(
+        observeGroupsUseCase(),
+        observeItemsByListUseCase(groupId),
+    ) { groups, items ->
+        val icons = ListCardIcon.entries
+        val colors = ListCardColor.entries
+        val group = groups.find { it.id == groupId }
+
+        val allGroupCards = groups.sortedBy { it.id }.map { g ->
+            GroupCardUiState(
+                groupId = g.id,
+                groupName = g.name,
+                items = emptyList(),
+                style = ListCardStyle(
+                    icon = icons[g.colorIndex % icons.size],
+                    accentColor = colors[g.colorIndex % colors.size],
+                ),
+            )
+        }
+
+        ViewAllUiState(
+            groupId = groupId,
+            groupName = group?.name ?: "",
+            items = items.sortedBy { it.isDone },
+            style = ListCardStyle(
+                icon = icons[(group?.colorIndex ?: 0) % icons.size],
+                accentColor = colors[(group?.colorIndex ?: 0) % colors.size],
+            ),
+            allGroups = allGroupCards,
+        )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = ViewAllUiState(groupId = groupId),
+    )
+
+    fun addItem(title: String) {
+        viewModelScope.launch(Dispatchers.IO) {
+            addItemUseCase(title = title, listId = groupId)
+        }
+    }
+
+    fun changeItemCheckStatus(id: String, checked: Boolean) {
+        viewModelScope.launch(Dispatchers.IO) {
+            updateItemStatusUseCase(id = id, isDone = checked)
+        }
+    }
+
+    fun updateItem(id: String, title: String, groupId: String, isDone: Boolean) {
+        viewModelScope.launch(Dispatchers.IO) {
+            updateItemTitleUseCase(id = id, title = title)
+            updateItemStatusUseCase(id = id, isDone = isDone)
+            if (groupId != this@ViewAllViewModel.groupId) {
+                moveItemUseCase(id = id, targetListId = groupId)
+            }
+        }
+    }
+
+    fun removeItem(id: String) {
+        viewModelScope.launch(Dispatchers.IO) {
+            deleteItemUseCase(id)
+        }
+    }
+}

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.ListIt" parent="android:Theme.Material.Light.NoActionBar" />
+    <style name="Theme.ListIt" parent="Theme.MaterialComponents.DayNight.NoActionBar" />
 </resources>

--- a/app/src/test/java/com/example/listit/data/fake/FakeListRepository.kt
+++ b/app/src/test/java/com/example/listit/data/fake/FakeListRepository.kt
@@ -29,4 +29,7 @@ class FakeListRepository : ListRepository {
     override suspend fun updateName(id: String, name: String) {
         _lists.value = _lists.value.map { if (it.id == id) it.copy(name = name) else it }
     }
+
+    override suspend fun getUsedColorIndices(): List<Int> =
+        _lists.value.map { it.colorIndex }
 }


### PR DESCRIPTION
                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                 Adds the View All Tasks screen, edit item functionality, and several UX improvements to the grouped card home screen.                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                 
  Changes                                                                                                       
                                                                                                                                                                                                                                                                                                 
  - Grouped card home screen — display lists as color-coded cards with icon, name, accent bar, and up to 3 item previews                                                                                                                                                                         
  - Persistent color assignment — each group gets a stable color (stored in DB) that doesn't shift when groups are added/removed
  - View All Tasks screen — full-screen scrollable list for a group with colored header block, back/settings icons, and FAB for adding items; respects status bar insets and supports two-line group names                                                                                       
  - Edit item bottom sheet — tap any item to edit its title, change its group, or toggle completion status                                                                                                                                                                                       
  - Strikethrough & sorting — checked items show strikethrough + dimmed text and sort below unchecked items                                                                                                                                                                                      
  - Empty state — groups with no items show centered "Nothing here yet" placeholder                                                                                                                                                                                                              
  - Keyboard save — pressing Done/Return in the add-item sheet triggers save                                                                                                                                                                                                                     
  - Dark theme fix — switch to DayNight XML theme and wrap NavGraph in Surface to eliminate white flash during navigation                                                                                                                                                                        
  - KDoc & previews — added documentation and Compose previews to all ViewModel-independent composables         