### PR TITLE
Build out Settings screen with persisted user preferences

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,6 +38,7 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
     packagingOptions {
         resources {
@@ -78,6 +79,9 @@ dependencies {
     implementation 'androidx.compose.ui:ui'
     implementation 'androidx.compose.ui:ui-tooling-preview'
     implementation 'androidx.compose.material3:material3'
+
+    // DataStore
+    implementation "androidx.datastore:datastore-preferences:1.1.4"
 
     // Hilt
     implementation "com.google.dagger:hilt-android:2.56.2"

--- a/app/src/main/java/com/example/listit/MainActivity.kt
+++ b/app/src/main/java/com/example/listit/MainActivity.kt
@@ -2,14 +2,20 @@ package com.example.listit
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
-import dagger.hilt.android.AndroidEntryPoint
 import androidx.activity.compose.setContent
-import androidx.navigation.NavHostController
-import androidx.navigation.compose.rememberNavController
-import com.example.listit.presentation.navigation.SetupNavGraph
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
+import com.example.listit.domain.model.ThemeMode
+import com.example.listit.presentation.MainViewModel
+import com.example.listit.presentation.navigation.SetupNavGraph
 import com.example.listit.ui.theme.ListItTheme
+import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -20,7 +26,18 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         setContent {
-            ListItTheme {
+            val viewModel: MainViewModel = hiltViewModel()
+            val themeState by viewModel.themeState.collectAsStateWithLifecycle()
+            val darkTheme = when (themeState.themeMode) {
+                ThemeMode.SYSTEM -> isSystemInDarkTheme()
+                ThemeMode.LIGHT -> false
+                ThemeMode.DARK -> true
+            }
+
+            ListItTheme(
+                darkTheme = darkTheme,
+                dynamicColor = themeState.useDynamicColor,
+            ) {
                 Surface(color = MaterialTheme.colorScheme.background) {
                     navController = rememberNavController()
                     SetupNavGraph(

--- a/app/src/main/java/com/example/listit/data/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/example/listit/data/repository/SettingsRepositoryImpl.kt
@@ -1,0 +1,47 @@
+package com.example.listit.data.repository
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.example.listit.domain.model.ThemeMode
+import com.example.listit.domain.model.UserSettings
+import com.example.listit.domain.repository.SettingsRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class SettingsRepositoryImpl @Inject constructor(
+    private val dataStore: DataStore<Preferences>,
+) : SettingsRepository {
+
+    private object Keys {
+        val THEME_MODE = stringPreferencesKey("theme_mode")
+        val USE_DYNAMIC_COLOR = booleanPreferencesKey("use_dynamic_color")
+        val SHOW_COMPLETED_ITEMS = booleanPreferencesKey("show_completed_items")
+    }
+
+    override fun observeSettings(): Flow<UserSettings> = dataStore.data.map { prefs ->
+        val themeMode = prefs[Keys.THEME_MODE]
+            ?.let { runCatching { ThemeMode.valueOf(it) }.getOrNull() }
+            ?: ThemeMode.SYSTEM
+        UserSettings(
+            themeMode = themeMode,
+            useDynamicColor = prefs[Keys.USE_DYNAMIC_COLOR] ?: true,
+            showCompletedItems = prefs[Keys.SHOW_COMPLETED_ITEMS] ?: true,
+        )
+    }
+
+    override suspend fun setThemeMode(mode: ThemeMode) {
+        dataStore.edit { it[Keys.THEME_MODE] = mode.name }
+    }
+
+    override suspend fun setUseDynamicColor(enabled: Boolean) {
+        dataStore.edit { it[Keys.USE_DYNAMIC_COLOR] = enabled }
+    }
+
+    override suspend fun setShowCompletedItems(show: Boolean) {
+        dataStore.edit { it[Keys.SHOW_COMPLETED_ITEMS] = show }
+    }
+}

--- a/app/src/main/java/com/example/listit/di/PreferencesModule.kt
+++ b/app/src/main/java/com/example/listit/di/PreferencesModule.kt
@@ -1,0 +1,35 @@
+package com.example.listit.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStoreFile
+import com.example.listit.data.repository.SettingsRepositoryImpl
+import com.example.listit.domain.repository.SettingsRepository
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class PreferencesModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindSettingsRepository(impl: SettingsRepositoryImpl): SettingsRepository
+
+    companion object {
+        @Provides
+        @Singleton
+        fun provideSettingsDataStore(
+            @ApplicationContext context: Context,
+        ): DataStore<Preferences> = PreferenceDataStoreFactory.create(
+            produceFile = { context.preferencesDataStoreFile("settings") },
+        )
+    }
+}

--- a/app/src/main/java/com/example/listit/domain/model/ThemeMode.kt
+++ b/app/src/main/java/com/example/listit/domain/model/ThemeMode.kt
@@ -1,0 +1,7 @@
+package com.example.listit.domain.model
+
+enum class ThemeMode {
+    SYSTEM,
+    LIGHT,
+    DARK,
+}

--- a/app/src/main/java/com/example/listit/domain/model/UserSettings.kt
+++ b/app/src/main/java/com/example/listit/domain/model/UserSettings.kt
@@ -1,0 +1,7 @@
+package com.example.listit.domain.model
+
+data class UserSettings(
+    val themeMode: ThemeMode = ThemeMode.SYSTEM,
+    val useDynamicColor: Boolean = true,
+    val showCompletedItems: Boolean = true,
+)

--- a/app/src/main/java/com/example/listit/domain/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/example/listit/domain/repository/SettingsRepository.kt
@@ -1,0 +1,12 @@
+package com.example.listit.domain.repository
+
+import com.example.listit.domain.model.ThemeMode
+import com.example.listit.domain.model.UserSettings
+import kotlinx.coroutines.flow.Flow
+
+interface SettingsRepository {
+    fun observeSettings(): Flow<UserSettings>
+    suspend fun setThemeMode(mode: ThemeMode)
+    suspend fun setUseDynamicColor(enabled: Boolean)
+    suspend fun setShowCompletedItems(show: Boolean)
+}

--- a/app/src/main/java/com/example/listit/domain/usecase/ObserveSettingsUseCase.kt
+++ b/app/src/main/java/com/example/listit/domain/usecase/ObserveSettingsUseCase.kt
@@ -1,0 +1,12 @@
+package com.example.listit.domain.usecase
+
+import com.example.listit.domain.model.UserSettings
+import com.example.listit.domain.repository.SettingsRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class ObserveSettingsUseCase @Inject constructor(
+    private val repository: SettingsRepository,
+) {
+    operator fun invoke(): Flow<UserSettings> = repository.observeSettings()
+}

--- a/app/src/main/java/com/example/listit/domain/usecase/UpdateDynamicColorUseCase.kt
+++ b/app/src/main/java/com/example/listit/domain/usecase/UpdateDynamicColorUseCase.kt
@@ -1,0 +1,10 @@
+package com.example.listit.domain.usecase
+
+import com.example.listit.domain.repository.SettingsRepository
+import javax.inject.Inject
+
+class UpdateDynamicColorUseCase @Inject constructor(
+    private val repository: SettingsRepository,
+) {
+    suspend operator fun invoke(enabled: Boolean) = repository.setUseDynamicColor(enabled)
+}

--- a/app/src/main/java/com/example/listit/domain/usecase/UpdateShowCompletedUseCase.kt
+++ b/app/src/main/java/com/example/listit/domain/usecase/UpdateShowCompletedUseCase.kt
@@ -1,0 +1,10 @@
+package com.example.listit.domain.usecase
+
+import com.example.listit.domain.repository.SettingsRepository
+import javax.inject.Inject
+
+class UpdateShowCompletedUseCase @Inject constructor(
+    private val repository: SettingsRepository,
+) {
+    suspend operator fun invoke(show: Boolean) = repository.setShowCompletedItems(show)
+}

--- a/app/src/main/java/com/example/listit/domain/usecase/UpdateThemeModeUseCase.kt
+++ b/app/src/main/java/com/example/listit/domain/usecase/UpdateThemeModeUseCase.kt
@@ -1,0 +1,11 @@
+package com.example.listit.domain.usecase
+
+import com.example.listit.domain.model.ThemeMode
+import com.example.listit.domain.repository.SettingsRepository
+import javax.inject.Inject
+
+class UpdateThemeModeUseCase @Inject constructor(
+    private val repository: SettingsRepository,
+) {
+    suspend operator fun invoke(mode: ThemeMode) = repository.setThemeMode(mode)
+}

--- a/app/src/main/java/com/example/listit/presentation/MainViewModel.kt
+++ b/app/src/main/java/com/example/listit/presentation/MainViewModel.kt
@@ -1,0 +1,38 @@
+package com.example.listit.presentation
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.listit.domain.model.ThemeMode
+import com.example.listit.domain.usecase.ObserveSettingsUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+
+/**
+ * UI state controlling app-wide theming, derived from persisted user settings.
+ */
+data class ThemeUiState(
+    val themeMode: ThemeMode = ThemeMode.SYSTEM,
+    val useDynamicColor: Boolean = true,
+)
+
+/**
+ * Holds theme state for the app's root composable. Eagerly collects so the correct
+ * theme is in place before the first frame, avoiding a flash on cold start.
+ */
+@HiltViewModel
+class MainViewModel @Inject constructor(
+    observeSettingsUseCase: ObserveSettingsUseCase,
+) : ViewModel() {
+
+    val themeState: StateFlow<ThemeUiState> = observeSettingsUseCase()
+        .map { ThemeUiState(themeMode = it.themeMode, useDynamicColor = it.useDynamicColor) }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Eagerly,
+            initialValue = ThemeUiState(),
+        )
+}

--- a/app/src/main/java/com/example/listit/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/listit/presentation/home/HomeViewModel.kt
@@ -7,6 +7,7 @@ import com.example.listit.domain.usecase.AddListUseCase
 import com.example.listit.domain.usecase.DeleteItemUseCase
 import com.example.listit.domain.usecase.ObserveGroupsUseCase
 import com.example.listit.domain.usecase.ObserveItemsUseCase
+import com.example.listit.domain.usecase.ObserveSettingsUseCase
 import com.example.listit.domain.usecase.MoveItemUseCase
 import com.example.listit.domain.usecase.UpdateItemStatusUseCase
 import com.example.listit.domain.usecase.UpdateItemTitleUseCase
@@ -26,6 +27,7 @@ import javax.inject.Inject
 class HomeViewModel @Inject constructor(
     observeItemsUseCase: ObserveItemsUseCase,
     observeGroupsUseCase: ObserveGroupsUseCase,
+    observeSettingsUseCase: ObserveSettingsUseCase,
     private val addItemUseCase: AddItemUseCase,
     private val addListUseCase: AddListUseCase,
     private val deleteItemUseCase: DeleteItemUseCase,
@@ -37,8 +39,10 @@ class HomeViewModel @Inject constructor(
     val groupCards: StateFlow<List<GroupCardUiState>> = combine(
         observeGroupsUseCase(),
         observeItemsUseCase(),
-    ) { groups, items ->
-        val itemsByListId = items.groupBy { it.listId }
+        observeSettingsUseCase(),
+    ) { groups, items, settings ->
+        val visibleItems = if (settings.showCompletedItems) items else items.filterNot { it.isDone }
+        val itemsByListId = visibleItems.groupBy { it.listId }
         val icons = ListCardIcon.entries
         val colors = ListCardColor.entries
 

--- a/app/src/main/java/com/example/listit/presentation/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/listit/presentation/navigation/NavGraph.kt
@@ -52,7 +52,7 @@ fun SetupNavGraph(
             route = ScreenNavigation.Settings.route
         ) {
             SettingsScreen(
-
+                navController = navController,
             )
         }
     }

--- a/app/src/main/java/com/example/listit/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/example/listit/presentation/settings/SettingsScreen.kt
@@ -1,43 +1,251 @@
 package com.example.listit.presentation.settings
 
-import androidx.compose.foundation.layout.Box
+import android.os.Build
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavController
+import com.example.listit.BuildConfig
+import com.example.listit.domain.model.ThemeMode
+import com.example.listit.domain.model.UserSettings
 import com.example.listit.ui.theme.ListItTheme
 
 /**
- * Placeholder settings screen with static text content.
- * Will house app-level configuration options in the future.
+ * App settings screen. Lets the user control theme appearance, list display behavior,
+ * and view app metadata. State is owned by [SettingsViewModel] and persisted via DataStore.
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SettingsScreen() {
-    Column {
-        Text(text = "Settings page")
+fun SettingsScreen(
+    navController: NavController,
+) {
+    val viewModel: SettingsViewModel = hiltViewModel()
+    val settings by viewModel.settings.collectAsStateWithLifecycle()
 
-        Text(
-            text = "This is where you enter your text",
-            fontSize = 38.sp,
-            lineHeight = 30.sp,
-        )
-        Box(
-            Modifier
-                .height(1.dp)
-                .fillMaxWidth()
+    SettingsScreenContent(
+        settings = settings,
+        onBack = { navController.navigateUp() },
+        onThemeModeChanged = viewModel::onThemeModeChanged,
+        onDynamicColorChanged = viewModel::onDynamicColorChanged,
+        onShowCompletedChanged = viewModel::onShowCompletedChanged,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SettingsScreenContent(
+    settings: UserSettings,
+    onBack: () -> Unit,
+    onThemeModeChanged: (ThemeMode) -> Unit,
+    onDynamicColorChanged: (Boolean) -> Unit,
+    onShowCompletedChanged: (Boolean) -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Settings") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.Filled.ArrowBack,
+                            contentDescription = "Back",
+                        )
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+        ) {
+            SectionHeader("Appearance")
+            ThemeModeSelector(
+                selected = settings.themeMode,
+                onSelected = onThemeModeChanged,
+            )
+            Spacer(Modifier.height(8.dp))
+            DynamicColorRow(
+                enabled = settings.useDynamicColor,
+                onEnabledChange = onDynamicColorChanged,
+            )
+
+            Spacer(Modifier.height(24.dp))
+            SectionHeader("Lists")
+            SwitchRow(
+                title = "Show completed items",
+                subtitle = "Display checked-off items in your lists",
+                checked = settings.showCompletedItems,
+                onCheckedChange = onShowCompletedChanged,
+            )
+
+            Spacer(Modifier.height(24.dp))
+            SectionHeader("About")
+            InfoRow(
+                title = "Version",
+                value = BuildConfig.VERSION_NAME,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SectionHeader(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.titleSmall,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier.padding(vertical = 8.dp),
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ThemeModeSelector(
+    selected: ThemeMode,
+    onSelected: (ThemeMode) -> Unit,
+) {
+    val options = listOf(
+        ThemeMode.SYSTEM to "System",
+        ThemeMode.LIGHT to "Light",
+        ThemeMode.DARK to "Dark",
+    )
+    SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+        options.forEachIndexed { index, (mode, label) ->
+            SegmentedButton(
+                selected = selected == mode,
+                onClick = { onSelected(mode) },
+                shape = SegmentedButtonDefaults.itemShape(index = index, count = options.size),
+            ) {
+                Text(label)
+            }
+        }
+    }
+}
+
+@Composable
+private fun DynamicColorRow(
+    enabled: Boolean,
+    onEnabledChange: (Boolean) -> Unit,
+) {
+    val supportsDynamic = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+    SwitchRow(
+        title = "Use dynamic color",
+        subtitle = if (supportsDynamic) {
+            "Match the app palette to your wallpaper"
+        } else {
+            "Requires Android 12 or newer"
+        },
+        checked = enabled && supportsDynamic,
+        onCheckedChange = onEnabledChange,
+        enabled = supportsDynamic,
+    )
+}
+
+@Composable
+private fun SwitchRow(
+    title: String,
+    subtitle: String?,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    enabled: Boolean = true,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyLarge,
+                color = if (enabled) {
+                    MaterialTheme.colorScheme.onSurface
+                } else {
+                    MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
+                },
+            )
+            if (subtitle != null) {
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+        Switch(
+            checked = checked,
+            onCheckedChange = onCheckedChange,
+            enabled = enabled,
         )
     }
 }
 
 @Composable
+private fun InfoRow(title: String, value: String) {
+    androidx.compose.foundation.layout.Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.bodyLarge,
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
 @PreviewLightDark
 private fun SettingsScreenPreview() {
     ListItTheme {
-        SettingsScreen()
+        SettingsScreenContent(
+            settings = UserSettings(),
+            onBack = {},
+            onThemeModeChanged = {},
+            onDynamicColorChanged = {},
+            onShowCompletedChanged = {},
+        )
     }
 }

--- a/app/src/main/java/com/example/listit/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/example/listit/presentation/settings/SettingsViewModel.kt
@@ -1,0 +1,44 @@
+package com.example.listit.presentation.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.listit.domain.model.ThemeMode
+import com.example.listit.domain.model.UserSettings
+import com.example.listit.domain.usecase.ObserveSettingsUseCase
+import com.example.listit.domain.usecase.UpdateDynamicColorUseCase
+import com.example.listit.domain.usecase.UpdateShowCompletedUseCase
+import com.example.listit.domain.usecase.UpdateThemeModeUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class SettingsViewModel @Inject constructor(
+    observeSettingsUseCase: ObserveSettingsUseCase,
+    private val updateThemeModeUseCase: UpdateThemeModeUseCase,
+    private val updateDynamicColorUseCase: UpdateDynamicColorUseCase,
+    private val updateShowCompletedUseCase: UpdateShowCompletedUseCase,
+) : ViewModel() {
+
+    val settings: StateFlow<UserSettings> = observeSettingsUseCase()
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = UserSettings(),
+        )
+
+    fun onThemeModeChanged(mode: ThemeMode) {
+        viewModelScope.launch { updateThemeModeUseCase(mode) }
+    }
+
+    fun onDynamicColorChanged(enabled: Boolean) {
+        viewModelScope.launch { updateDynamicColorUseCase(enabled) }
+    }
+
+    fun onShowCompletedChanged(show: Boolean) {
+        viewModelScope.launch { updateShowCompletedUseCase(show) }
+    }
+}


### PR DESCRIPTION
Adds a DataStore-backed SettingsRepository, use cases, and a Settings screen with theme mode (System/Light/Dark), dynamic color toggle, show completed items toggle, and app version. Theme is collected eagerly in MainActivity to avoid a cold-start flash.